### PR TITLE
Do not output trailing newline in Debug output

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ See example.
 ```console
 $ cargo run --example simple -q -- foo
 Error: Can't read file `foo`
-        cause: No such file or directory (os error 2)
+Info: caused by No such file or directory (os error 2)
 ```
 
 ```console
 $ cargo run --example simple -q -- foo
 Error: Can't read file `foo`
-        cause: No such file or directory (os error 2)
+Info: caused by No such file or directory (os error 2)
 ```
 
 ## License

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,18 +12,18 @@ pub fn derive_parser(input: TokenStream) -> TokenStream {
     let impl_block = quote::quote! {
         impl ::std::fmt::Debug for #name {
             fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-                ::std::writeln!(f, "{}", self)?;
+                ::std::write!(f, "{}", self)?;
 
                 let mut e: &dyn ::std::error::Error = self;
                 while let Some(source) = e.source() {
-                    ::std::writeln!(f, "\tcause: {}", source)?;
+                    ::std::write!(f, "\nInfo: caused by {}", source)?;
                     e = source;
                 }
 
                 if ::std::env::var("RUSTC_BACKTRACE").is_ok()
                     || ::std::env::var("RUST_BACKTRACE").is_ok() {
                     if let Some(backtrace) = ::snafu::ErrorCompat::backtrace(&self) {
-                        ::std::writeln!(f, "{}", backtrace)?;
+                        ::std::write!(f, "\n{}", backtrace)?;
                     }
                 }
 


### PR DESCRIPTION
When errors are printed by returning them from fn main the standard
library adds a newline for us, so it is not needed. This matches the
behaviour of the popular exitfailure crate. Also the "caused by" line
is changed to match that of exitfailure.

See <https://github.com/tismith/exitfailure/blob/22eb1999c2/src/lib.rs#L59-L76>

Thanks for this useful crate.